### PR TITLE
Add Jira ticket link support

### DIFF
--- a/index.js
+++ b/index.js
@@ -270,6 +270,12 @@ controller.hears(["goodnews", "good news"], ["ambient"], function(bot, message) 
   bot.reply(message, "https://media.giphy.com/media/3zFcbgHoIXzykQc7vU/giphy.gif");
 });
 
+controller.hears(["shame"], ["ambient"], function(bot, message) {
+  bot.reply(message, "https://media.giphy.com/media/vX9WcCiWwUF7G/200w_d.gif");
+});
+
+
+
 controller.hears(["timesheets"], ["ambient"], function(bot, message) {
   bot.reply(
     message,
@@ -628,7 +634,6 @@ controller.hears (
 );
 
 
-
 controller.hears (
   [
   "pagerduty",
@@ -641,6 +646,18 @@ controller.hears (
     bot.reply(message, pagerduty_offhours());
   }
 );
+
+
+
+
+controller.hears (
+  new RegExp("\b([A-Z]{3,8}-[0-9]{1,5})\b", "gi"), ["ambient"], function(bot, message) {
+  pattern = new RegExp("\b([A-Z]{3,8}-[0-9]{1,5})\b", "gi");
+  while (match = pattern.exec(message.text)) {
+    ticket_number = match[1].toUpperCase();
+    bot.reply(message, "https://jira.cms.gov/browse/" + ticket_number);
+  }
+});
 
 
 /**


### PR DESCRIPTION
This does nothing fancy..  if it sees something that looks like it might
be a Jira ticket number (e.g., 'QPPCP-3050') in a message, Flexibot will
respond with a link to that ticket in Jira.  It literally prepends a
base string ('https://jira.cms.gov/browse/') with the ticket number.

Oh, and there's another Easter Egg in there (which is obvious from the
git diff).