### PR TITLE
Change Jira ticket regex to be more selective

### DIFF
--- a/index.js
+++ b/index.js
@@ -751,8 +751,8 @@ controller.hears (
 
 
 controller.hears (
-  new RegExp(/\W*([A-Z]{3,8}-[0-9]{1,5})\W*/, "gi"), ["ambient"], function(bot, message) {
-  pattern = new RegExp(/\W*([A-Z]{3,8}-[0-9]{1,5})\W*/, "gi");
+  new RegExp(/\W*((qpp|qta|waka|cmsawsops|tools|whsd)[a-z]*-[0-9]{1,5})\W*/, "gi"), ["ambient"], function(bot, message) {
+  pattern = new RegExp(/\W*((qpp|qta|waka|cmsawsops|tools|whsd)[a-z]*-[0-9]{1,5})\W*/, "gi");
 
   var response_string = "";
 


### PR DESCRIPTION
The Jira ticket regex was picking up stupid things like us-east-1 which
is not ticket number.  So, the regex has been replaced with a more
discerning version that should prevent that from happening any more.