### PR TITLE
Only return links to tickets numbers, not URLs

### DIFF
--- a/index.js
+++ b/index.js
@@ -758,14 +758,20 @@ controller.hears (
 
   while (match = pattern.exec(message.text)) {
     ticket_number = match[1].toUpperCase();
-    response_string =
-      response_string
-      + "*"
-      + ticket_number
-      + "*"
-      + ": https://jira.cms.gov/browse/"
-      + ticket_number
-      + "\n";
+    prefix = "*" + ticket_number + "*: ";
+    suffix = "\n";
+    url = "https://jira.cms.gov/browse/" + ticket_number;
+
+    // only add URL if the message (from the user) or the response (from Flexibot)
+    // does not include the URL to that ticket
+    if ((message.indexOf (url) == -1)
+    && (response_string.indexOf (url) == -1)) {
+      response_string =
+        response_string
+        + prefix
+        + url
+        + suffix;
+    }
   }
 
   bot.reply(message, response_string);


### PR DESCRIPTION
Previously, if the user would provide one or more ticket numbers,
Flexibot would blindly create links to those tickets.  Cool.

However, if the user provided the URL to the ticket, Flexibot would
recreate the URL and respond with it... which wasn't helpful.  Also, if
the ticket number was already included in the response (from Flexibot),
Flexibot would say it again.. which, again, wasn't helpful.

So, now if the full URL to the ticket exists in either the message (from
the user) or the response (from Flexibot), the URL will not be included
in the response.

Also, the method for creating the response was cleaned-up to be a little
more legible and/or useful for extension.