### PR TITLE
Add "time" command

### DIFF
--- a/index.js
+++ b/index.js
@@ -599,6 +599,20 @@ controller.hears(
   acronymicon
 );
 
+controller.hears (
+  [
+    "time"
+  ],
+  [
+    "direct_metion", "mention", "direct_message"
+  ],
+  function (bot, message) {
+    right_now = new Date();
+    now_string = right_now.toString();
+    bot.reply (message, now_string ());
+  }
+);
+
 
 controller.hears (
   [

--- a/offhours/test.js
+++ b/offhours/test.js
@@ -84,7 +84,7 @@ function test_date (offhours, the_date, before, after, weekend, holiday, result)
 }
 
 
-var offhours = require ('./offhours/offhours.js');
+var offhours = require ('./offhours.js');
 
 // noon UTC on Monday, June 24, 2019 (during work hours)
 date1 = new Date ('June 24, 2019 12:00:00');


### PR DESCRIPTION
I don't know what's up with Flexibot not handling the pagerduty stuff.
At the same time, I don't know what time Flexibot thinks it is.  So,
this command just up and asks Flexibot to respond with the current time.

To make it go, send "time" (no quotes) to Flexibot.