### PR TITLE
Cleanup and refector RegExp for jira_matcher

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,0 +1,13 @@
+env:
+  browser: false
+  es6: true
+  node: true
+
+extends: 'eslint:recommended'
+globals:
+  Atomics: readonly
+  SharedArrayBuffer: readonly
+parserOptions:
+  ecmaVersion: 2018
+  sourceType: module
+rules: {}

--- a/index.js
+++ b/index.js
@@ -220,14 +220,14 @@ controller.hears(
         bot.reply(message, JSON.stringify(result));
       });
     } else {
-      my_weather = "Please provide a zipcode of a town,state with no spaces";
+      var my_weather = "Please provide a zipcode of a town,state with no spaces";
       bot.reply(message, my_weather);
     }
   }
 );
 
 controller.hears(["standup_list"], ["ambient"], function(bot, message) {
-  list = standup_list();
+  var list = standup_list();
   console.log(list);
   bot.reply(message, list);
 });
@@ -319,7 +319,7 @@ controller.hears(["free bird", "freebird"], ["ambient"], function(
 });
 
 controller.hears(["Friday", "friday"], ["ambient"], function(bot, message) {
-  day_of_week = new Date().getDay();
+  var day_of_week = new Date().getDay();
   switch (day_of_week) {
     case 6:
     case 0:
@@ -608,8 +608,8 @@ controller.hears (
     "direct_mention", "mention", "direct_message"
   ],
   function (bot, message) {
-    right_now = new Date();
-    now_string = right_now.toString();
+    var right_now = new Date();
+    var now_string = right_now.toString();
     bot.reply (message, now_string);
   }
 );
@@ -646,11 +646,11 @@ controller.hears (
 
 
 controller.hears (
-  jira_regex, 
+  new RegExp (jira_regex), 
   [ "ambient" ],
   function (bot, message) {
   
-  response_string = jira_matcher.add_ticket_urls (message);
+  var response_string = jira_matcher.add_ticket_urls (message);
 
   // only say something if there's something that needs to be said
   if (response_string != "") {

--- a/jira_matcher/jira_matcher.js
+++ b/jira_matcher/jira_matcher.js
@@ -26,7 +26,7 @@ module.exports = {
       return false;
     }
 
-    pattern = new RegExp (this.jira_regex (), 'gi');
+    var pattern = new RegExp (this.jira_regex (), 'gi');
 
     return pattern.test (string);
 
@@ -44,7 +44,7 @@ module.exports = {
 
 
   get_ticket_numbers: function (string) {
-    pattern = new RegExp (this.jira_regex (), 'gi');
+    var pattern = new RegExp (this.jira_regex (), 'gi');
   
     return string.match (pattern);
 
@@ -53,7 +53,7 @@ module.exports = {
   
   is_ticket_in_message: function (string, ticket_number) {
     
-    pattern = new RegExp (this.ticket_url (ticket_number));
+    var pattern = new RegExp (this.ticket_url (ticket_number));
 
     return pattern.test (string);
   },
@@ -61,17 +61,17 @@ module.exports = {
 
   add_ticket_urls: function (string) {
 
-    tickets = this.get_ticket_numbers (string);
+    var tickets = this.get_ticket_numbers (string);
     
     if (tickets == null) {
       return false;
     }
 
-    reply = '';
+    var reply = '';
 
     
     for (var i = 0; i < tickets.length; i++) {
-      ticket_number = tickets[i].toUpperCase();
+      var ticket_number = tickets[i].toUpperCase();
       if ((! this.is_ticket_in_message (string, ticket_number))
       && (! this.is_ticket_in_message (reply, ticket_number))) {
         reply += this.ticket_string (ticket_number) + this.ticket_url (ticket_number) + "\n";

--- a/offhours/offhours.js
+++ b/offhours/offhours.js
@@ -15,11 +15,11 @@ module.exports = {
       the_date = new Date();
     }
 
-    the_day = the_date.getUTCDay();
+    var the_day = the_date.getUTCDay();
 
     if ((the_day == 0)     // Sunday
     ||  (the_date == 6)) { // Saturday
-      return true;  
+      return true;
     } else {
       return false;
     }
@@ -34,8 +34,10 @@ module.exports = {
 /// @param {Date} dt_date the date to examine (defaults to today)
 /// @param {Integer} start_hour the first hour of work (defaults to 9am Eastern))
 /// @param {Integer} tzoffset the timezone offset (defaults to -5 (Eastern)
-/// @returns {Boolean} True if after work; False, otherwise 
+/// @returns {Boolean} True if after work; False, otherwise
   is_before_hours: function (the_date, start_hour, tzoffset) {
+
+    var dstoffset = 0;
 
     if (typeof (the_date) === 'undefined') {
       the_date = new Date();
@@ -55,7 +57,7 @@ module.exports = {
       dstoffset = 0;
     }
 
-    the_hour = the_date.getUTCHours() + dstoffset + tzoffset;
+    var the_hour = the_date.getUTCHours() + dstoffset + tzoffset;
 
     if (the_hour < start_hour) {
       return true;
@@ -73,8 +75,10 @@ module.exports = {
 /// @param {Date} dt_date the date to examine (defaults to today)
 /// @param {Integer} end_hour the first hour after work (defaults to 5pm Eastern)
 /// @param {Integer} tzoffset the timezone offset (defaults to -5 (Eastern)
-/// @returns {Boolean} True if after work; False, otherwise 
+/// @returns {Boolean} True if after work; False, otherwise
   is_after_hours: function (the_date, end_hour, tzoffset) {
+
+    var dstoffset = 0;
 
     if (typeof (the_date) === 'undefined') {
       the_date = new Date();
@@ -94,7 +98,7 @@ module.exports = {
       dstoffset = 0;
     }
 
-    the_hour = the_date.getUTCHours() + dstoffset + tzoffset;
+    var the_hour = the_date.getUTCHours() + dstoffset + tzoffset;
 
     if (the_hour >= end_hour) {
       return true;
@@ -119,16 +123,16 @@ module.exports = {
     }
 
 // check simple dates (month/date - no leading zeroes)
-	  var n_date = dt_date.getUTCDate(),
-	  	n_month = dt_date.getUTCMonth() + 1;
+    var n_date = dt_date.getUTCDate(),
+      n_month = dt_date.getUTCMonth() + 1;
 
     // weekday from beginning of the month (month/num/day)
-	  var n_wday = dt_date.getDay(),
-		  n_wnum = Math.floor((n_date - 1) / 7) + 1;
+    var n_wday = dt_date.getDay(),
+      n_wnum = Math.floor((n_date - 1) / 7) + 1;
 
-	  var s_date2 = n_month + '/' + n_wnum + '/' + n_wday;
+    var s_date2 = n_month + '/' + n_wnum + '/' + n_wday;
 
-	  if ((s_date2 >= '3/2/0')  // DST starts 2nd Sunday of March...
+    if ((s_date2 >= '3/2/0')  // DST starts 2nd Sunday of March...
     &&  (s_date2 <  '11/1/1') // and ends 1st Sunday of November.
     ) {
       return true;
@@ -148,52 +152,52 @@ module.exports = {
   is_holiday: function (dt_date) {
 
     if (typeof (dt_date) === 'undefined') {
-      var dt_date = new Date();
+      dt_date = new Date();
     }
 
-	  // check simple dates (month/date - no leading zeroes)
-	  var n_date = dt_date.getUTCDate(),
-	  	n_month = dt_date.getUTCMonth() + 1;
+    // check simple dates (month/date - no leading zeroes)
+    var n_date = dt_date.getUTCDate(),
+      n_month = dt_date.getUTCMonth() + 1;
 
-  	var s_date1 = n_month + '/' + n_date;
+    var s_date1 = n_month + '/' + n_date;
 
-	  if (s_date1 == '1/1'   // New Year's Day
-	  	|| s_date1 == '6/14'  // Flag Day
-  		|| s_date1 == '7/4'   // Independence Day
-   		|| s_date1 == '11/11' // Veterans Day
-	  	|| s_date1 == '12/25' // Christmas Day
-	  ) return true;
+    if (s_date1 == '1/1'   // New Year's Day
+      || s_date1 == '6/14'  // Flag Day
+      || s_date1 == '7/4'   // Independence Day
+      || s_date1 == '11/11' // Veterans Day
+      || s_date1 == '12/25' // Christmas Day
+    ) return true;
 
-	  // weekday from beginning of the month (month/num/day)
-	  var n_wday = dt_date.getDay(),
-		  n_wnum = Math.floor ((n_date - 1) / 7) + 1;
+    // weekday from beginning of the month (month/num/day)
+    var n_wday = dt_date.getDay(),
+      n_wnum = Math.floor ((n_date - 1) / 7) + 1;
 
-	  var s_date2 = n_month + '/' + n_wnum + '/' + n_wday;
+    var s_date2 = n_month + '/' + n_wnum + '/' + n_wday;
 
-	  if (s_date2 == '1/3/1'  // Birthday of Martin Luther King, third Monday in January
-		  || s_date2 == '2/3/1'  // Washington's Birthday, third Monday in February
-		  || s_date2 == '9/1/1'  // Labor Day, first Monday in September
-		  || s_date2 == '10/2/1' // Columbus Day, second Monday in October
-		  || s_date2 == '11/4/4' // Thanksgiving Day, fourth Thursday in November
-	  ) return true;
+    if (s_date2 == '1/3/1'  // Birthday of Martin Luther King, third Monday in January
+      || s_date2 == '2/3/1'  // Washington's Birthday, third Monday in February
+      || s_date2 == '9/1/1'  // Labor Day, first Monday in September
+      || s_date2 == '10/2/1' // Columbus Day, second Monday in October
+      || s_date2 == '11/4/4' // Thanksgiving Day, fourth Thursday in November
+    ) return true;
 
-	  // weekday number from end of the month (month/num/day)
-	  var dt_temp = new Date (dt_date);
+    // weekday number from end of the month (month/num/day)
+    var dt_temp = new Date (dt_date);
 
-	  dt_temp.setDate (1);
-  	dt_temp.setMonth (dt_temp.getMonth () + 1);
-  	dt_temp.setDate (dt_temp.getDate () - 1);
+    dt_temp.setDate (1);
+    dt_temp.setMonth (dt_temp.getMonth () + 1);
+    dt_temp.setDate (dt_temp.getDate () - 1);
 
-	  n_wnum = Math.floor ((dt_temp.getDate () - n_date - 1) / 7) + 1;
+    n_wnum = Math.floor ((dt_temp.getDate () - n_date - 1) / 7) + 1;
 
-	  var s_date3 = n_month + '/' + n_wnum + '/' + n_wday;
+    var s_date3 = n_month + '/' + n_wnum + '/' + n_wday;
 
 
-	  if ((s_date3 == '5/1/1')  // Memorial Day, last Monday in May
-	  ) {
+    if ((s_date3 == '5/1/1')  // Memorial Day, last Monday in May
+    ) {
       return true;
     } else {
-	    return false;
+      return false;
     }
 
   },


### PR DESCRIPTION
I used eslint to cleanup all of the oddities in the offhours and
jira_matcher libraries and some of index.js, added the config file I
used with eslint, and captured the regular expression we use with
jira_matcher as a string then used that as the matcher for jira tickets.